### PR TITLE
Hide settings without database

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,7 @@
 module ApplicationHelper
   include Twitter::TwitterText::Autolink
+
+  def database_present?
+    ENV['MONGO_URL'].present?
+  end
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -12,8 +12,10 @@
       <%= render 'search/form' %>
     <% end %>
 
-    <div class="navbar-nav ml-auto">
-        <%= link_to 'Settings', edit_settings_path, class: "nav-item nav-link pb-0 pr-0 ml-2 #{content_for(:page) == 'settings' ? 'active' : ''}" %>
-    </div>
+    <% if database_present? %>
+      <div class="navbar-nav ml-auto">
+          <%= link_to 'Settings', edit_settings_path, class: "nav-item nav-link pb-0 pr-0 ml-2 #{content_for(:page) == 'settings' ? 'active' : ''}" %>
+      </div>
+    <% end %>
   </div>
 </nav>


### PR DESCRIPTION
The user settings are needed only if a database is present, but the app works fine without it.