### PR TITLE
Fix atom content type

### DIFF
--- a/app/views/search/index.atom.builder
+++ b/app/views/search/index.atom.builder
@@ -8,7 +8,7 @@ atom_feed do |feed|
   @results.each do |item|
     feed.entry(item, id: item.via, url: item.via) do |entry|
       entry.title(item.title)
-      entry.content(item.html, type: 'text/html') if item.html
+      entry.content(item.html, type: 'html') if item.html
       entry.link(rel: 'related', type: 'text/html', href: item.url) if item.url
 
       if item.author


### PR DESCRIPTION
The type of `link` is `text/html` but the type of `content` must be `html`.